### PR TITLE
Issue #1 make the unicode_decode_error_handler option configurable

### DIFF
--- a/mongo_connector/service/config.json
+++ b/mongo_connector/service/config.json
@@ -3,6 +3,7 @@
     "__comment__": "To enable them, remove the preceding '__'",
 
     "mainAddress": "localhost:27017",
+    "unicodeDecode": "strict",
     "oplogFile": "/var/log/mongo-connector/oplog.timestamp",
     "noDump": false,
     "batchSize": -1,


### PR DESCRIPTION
Adding the unicode_decode_error_handler option to the pymongo connection.
This defaults to ignore and can be changed to either replace or ignore by using the `--decode-handler` flag or setting it in the config.json `"unicodeDecode": "replace"`.